### PR TITLE
Enable L9 processing and housekeeping

### DIFF
--- a/bash/update-metadata-csd.sh
+++ b/bash/update-metadata-csd.sh
@@ -22,7 +22,7 @@ docker run \
 -w $PWD \
 -u $(id -u):$(id -g) \
 $IMAGE \
-force-level1-csd -u $DIR_CSD_META
+force-level1-csd -u $DIR_CSD_META -s s2a
 
 exit 0
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -1,4 +1,4 @@
-FORCE_IMAGE = davidfrantz/force:3.7.0
+FORCE_IMAGE = davidfrantz/force:3.7.6
 LANDSATLINKS_IMAGE = ernstste/landsatlinks
 
 DIR_CSD_META = /data/Dagobah/dc/input


### PR DESCRIPTION
- Change force version to 3.7.6 to allow Landsat 9 Level-2 processing
- make sure force-level1-csd only downloads the Sentinel-2 metadata catalogue as Landsat data is not pulled from GCS