### PR TITLE
Updates config.txt

### DIFF
--- a/bash/download-wvdb.sh
+++ b/bash/download-wvdb.sh
@@ -21,6 +21,8 @@ CONFIG=$1
 # parse config file
 IMAGE=$("$BIN"/read-config.sh "FORCE_IMAGE" "$CONFIG")
 DIR_WVP=$("$BIN"/read-config.sh "DIR_WVP" "$CONFIG")
+USER_GROUP=$("$BIN"/read-config.sh "USER_GROUP" "$CONFIG" "$(id -u):$(id -g)")
+DIR_CREDENTIALS=$("$BIN"/read-config.sh "DIR_CREDENTIALS" "$CONFIG" "$HOME")
 
 # date
 if [ $# -eq 1 ]; then
@@ -42,7 +44,7 @@ fi
 
 echo "$YEAR $MONTH $DAY"
 
-TEMPDIR="$DIR_WVP/hdf-$YEAR-$MONTH-$DAY"
+TEMPDIR="$DIR_WVP/tmp/hdf-$YEAR-$MONTH-$DAY"
 
 mkdir -p "$TEMPDIR"
 
@@ -51,14 +53,14 @@ docker run \
 --rm \
 -e FORCE_CREDENTIALS=/app/credentials \
 -e BOTO_CONFIG=/app/credentials/.boto \
--v "$HOME:/app/credentials" \
+-v "$DIR_CREDENTIALS:/app/credentials" \
 -v /codede:/codede \
 -v /data:/data \
 -v /force:/force \
 -v /mnt:/mnt \
 -v "$HOME:$HOME" \
 -w "$PWD" \
--u "$(id -u):$(id -g)" \
+-u "$USER_GROUP" \
 "$IMAGE" \
 force-lut-modis \
   -d "$YEAR$MONTH$DAY,$YEAR$MONTH$DAY" \

--- a/bash/read-config.sh
+++ b/bash/read-config.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
-
+# use: read-config.sh PARAMETER_NAME config.txt [DEFAULT_VALUE]
 PROG=$(basename "$0")
-#BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 
 # get config file
-if [ $# -ne 2 ] ; then 
-  echo "wrong number of arguments" 1>&2;
+if [ $# -lt 2 ] || [ $# -gt 3 ];  then 
+  echo "wrong number of arguments ($#)" 1>&2;
   echo "1: tag" 1>&2;
   echo "2: configuration file" 1>&2;
+  echo "3: default value (optional)" 1>&2
   exit 1
 fi
+
 TAG=$1
 CONFIG=$2
+DEFAULT=$3
 
 # config found?
 if [ ! -r "$CONFIG" ]; then
@@ -26,8 +27,12 @@ VALUE=$(grep "^$TAG " "$CONFIG" | sed 's/.* *= *//')
 
 # read successful?
 if [ -z "$VALUE" ]; then
-  echo "$TAG not found in config.txt" 1>&2;
-  exit 1
+  if [ -n "$DEFAULT" ]; then
+    VALUE="$DEFAULT"
+  else
+    echo "$TAG not found in $CONFIG" 1>&2
+    exit 1
+  fi
 fi
 
 # print value

--- a/bash/update-wvdb.sh
+++ b/bash/update-wvdb.sh
@@ -35,7 +35,7 @@ DIR_WVP=$("$BIN"/read-config.sh "DIR_WVP" "$CONFIG")
 
 # start and end dates
 #d=2000-02-24
-d=2021-06-01
+d=$("$BIN"/read-config.sh "WVP_START" "$CONFIG" "2021-06-01") 
 #d=2021-01-01
 #d=2021-06-19
 #d=$(date --date "30 days ago")

--- a/config/config.txt
+++ b/config/config.txt
@@ -1,4 +1,17 @@
-FORCE_IMAGE = davidfrantz/force:3.7.10
+FORCE_IMAGE = davidfrantz/force:3.10.04
+
+# overwrite user- and group id 
+# defaults to "$(id -u):$(id -g)"
+# USER_GROUP = 1234:5678
+
+# overwrite WVPD 
+# defaults to "2021-06-01", see update-wvdb.sh
+# WVP_START = 
+
+# overwrite DIR_CREDENTIALS 
+# defaults to $HOME
+# DIR_CREDENTIALS = 
+
 LANDSATLINKS_IMAGE = ernstste/landsatlinks
 
 DIR_CSD_META = /data/ahsoka/dc/input


### PR DESCRIPTION
This PR  enhances _read-config.sh_ to allow for reading of optional parameters and adds support for 3 new optional parameters in the config.txt

1. read-config.sh can be called like

````bash
# syntax: read-config.sh PARAMETER_NAME config.txt [DEFAULT_VALUE]
read-config.sh "MY_PARAMETER" $PATH_CONFIG_FILE "default_value"
````
If my MY_PARAMETER does not exist, the default value will be used. This allows to define 
optional config settings, as in the following:

2. `USER_GROUP` allows to overwrite the default user and group id that is returned by `"$(id -u):$(id -g)"`, e.g. in

```bash
docker run \
--rm \
...
-u "$(id -u):$(id -g)" \
"$IMAGE" \
force-level1-csd \
```

This allows to create files with user rights different to the UID and GID of the user that started the bash script & docker process. For example, my "standard" uid and gui are: uid=7001(jakimowb) gid=9000(eolab). 
Adding `USER_GROUP = 7001:9003` to the config.txt ensures that FORCE creates files with uid=7001(jakimowb), gid=9003(datacube), so that all datacube users have access to.

3. WVP_START 

Allows to overwrite the d paramter in update-wvdb.sh, i.e. the start date to download WV data for

4. DIR_CREDENTIALS

By default, many bash scripts assume that the credentials are located in $HOME

```bash
docker run \
--rm \
...
-v "$HOME:/app/credentials" \
...
"$IMAGE" \
force-level1-csd \
```
DIR_CREDENTIALS allows to overwrite this default location, e.g.
`DIR_CREDENTIALS = /home/myuseraccount/.credentials`


